### PR TITLE
Improve README docs and add pipeline descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
 # Hematokytos
 
-Hematokytos - 'Blood cell.' 
+Hematokytos - "Blood cell."
 
 
 ## Overview
 
-This project provides tools and pipelines for collecting, integrating, and analyzing single-cell data from direct reprogramming experiments and related native hematopoietic cell types. It includes workflows for preprocessing, quality control, RNA velocity, and downstream cell state characterization, with a focus on hematopoietic stem cells, progenitor cells, endothelial cells and fibroblasts.
+This repository provides a set of pipelines and utilities for collecting, integrating and analysing single-cell data from direct reprogramming experiments and related native hematopoietic cell types. Workflows cover preprocessing, quality control, RNA velocity and network analysis with a focus on hematopoietic stem and progenitor cells.
 
 
 
 ## Repository Structure
 
-- `cc_pipeline/` – Cell cycle raw data pipeline
-- `hsc_pipeline/` – Direct reprogramming raw data pipeline
-- `notebooks/` – Jupyter notebooks for exploratory data analysis and figure generation
+- `pipelines/` – Collection of workflow scripts
+  - `cc_pipeline/` – Nextflow pipeline for cell cycle samples
+  - `bm_pipeline/` – Nextflow pipeline for bone marrow data
+  - `hsc_pipeline/` – Nextflow pipeline for direct reprogramming experiments
+  - `velocyto_pipeline/` – Snakemake workflow for running Velocyto
+  - `DeepCycle/` – Scripts to run the DeepCycle model
+  - `CABYBARA/` – Capybara cell identity assignment scripts
+  - `scMINER/` – Network inference with SJARACNe
+- `notebooks/` – Jupyter notebooks for exploratory analysis and figure generation
 - `reference_atlas/` – Scripts for collecting and annotating reference datasets
-- `resources/` – Gene sets, metadata, and supporting files
-- `velocyto_pipeline/` – RNA velocity pipeline
+- `resources/` – Gene sets, metadata and supporting files
+- `NextCell/` – Exploration of the NextCell algorithm
+- `results/` – Example output tables
+- `utils/` – Small helper modules
+
+Each pipeline directory contains its own README with usage instructions.
 

--- a/pipelines/CABYBARA/README.md
+++ b/pipelines/CABYBARA/README.md
@@ -1,0 +1,11 @@
+# CAPYBARA Scripts
+
+A collection of shell wrappers and an R script for running [Capybara](https://github.com/nstoparczyk/capybara) to assign cell identities.
+
+## Contents
+- `run_capybara.R` – Core R script that performs Capybara label assignment
+- `capybara_*.sh` – Example SLURM submission scripts for different analyses
+- `simplify.ipynb` – Notebook demonstrating how results can be simplified
+
+## Usage
+Modify the input and output paths inside the shell scripts and submit them via `sbatch`. The R script expects an AnnData `.h5ad` input and a reference dataset.

--- a/pipelines/DeepCycle/README.md
+++ b/pipelines/DeepCycle/README.md
@@ -1,0 +1,10 @@
+# DeepCycle Scripts
+
+Utilities for running the [DeepCycle](https://github.com/MCalebO/DeepCycle) model to estimate cell-cycle position.
+
+## Contents
+- `run_deepcycle.sh` – Example SLURM submission script invoking `DeepCycle.py`
+- `DeepCycle/` – Directory containing model weights and output files
+
+## Usage
+Edit the variables in `run_deepcycle.sh` to point to your data and submit it with `sbatch`. GPU resources are recommended.

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,4 +1,13 @@
 # Pipelines
 
-## Overview
+This directory houses the workflow scripts used throughout the project. Each subfolder contains the configuration and helper scripts for a specific analysis pipeline.
 
+- `cc_pipeline/` – Nextflow workflow for processing cell cycle datasets
+- `bm_pipeline/` – Nextflow workflow for bone marrow single-cell data
+- `hsc_pipeline/` – Nextflow workflow for direct reprogramming experiments
+- `velocyto_pipeline/` – Snakemake pipeline to produce Velocyto spliced/unspliced counts
+- `DeepCycle/` – Scripts to run the DeepCycle model
+- `CABYBARA/` – Capybara-based cell identity assignment scripts
+- `scMINER/` – Gene regulatory network inference using SJARACNe
+
+Each pipeline folder includes a README describing how to run the workflow.

--- a/pipelines/scMINER/README.md
+++ b/pipelines/scMINER/README.md
@@ -1,0 +1,13 @@
+# scMINER Pipeline
+
+This folder contains a helper script to run gene regulatory network inference using the SJARACNe implementation from scMINER.
+
+## Contents
+- `network_inference.sh` – SLURM batch script that loops over clusters and launches `sjaracne`.
+
+## Usage
+Edit the paths at the top of `network_inference.sh` to match your data locations and submit it with `sbatch`:
+
+```bash
+sbatch network_inference.sh
+```

--- a/pipelines/velocyto_pipeline/README.md
+++ b/pipelines/velocyto_pipeline/README.md
@@ -1,0 +1,19 @@
+# Velocyto Pipeline
+
+A Snakemake workflow for generating spliced and unspliced count matrices using [Velocyto](https://velocyto.org/). The pipeline merges BAM files, prepares barcodes and runs `velocyto.py`.
+
+## Contents
+- `Snakefile` – Main workflow description
+- `config.yaml` – Configuration file with sample information
+- `prep_velocyto.py` – Helper script to adjust BAM files
+- `slurm_submit.sh` – Example submission script for a SLURM cluster
+- `velocyto.yml` – Conda environment for Velocyto
+
+## Usage
+Adjust paths in `config.yaml` and run:
+
+```bash
+snakemake --use-conda --cores 32
+```
+
+Alternatively submit `slurm_submit.sh` to your cluster.


### PR DESCRIPTION
## Summary
- expand project overview and repository structure in main `README.md`
- describe each pipeline in `pipelines/README.md`
- add new READMEs for pipeline directories: `CABYBARA`, `DeepCycle`, `scMINER` and `velocyto_pipeline`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684041edfcec8331ac6ebeb5073e947b